### PR TITLE
CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jhnc-oss/yocto-image/yocto:latest
+      options: --user root
+    name: "Build"
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          pip install -r requirements.txt
+          git clone git://git.yoctoproject.org/poky --depth 1 --branch dunfell-23.0.9 /opt/yocto/poky
+      - name: Build
+        run: |
+          source poky/oe-init-build-env
+          bitbake -p zlib
+        shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
+        working-directory: /opt/yocto

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Yocto Build
 
+[![ci](https://github.com/jhnc-oss/yocto-build/actions/workflows/ci.yml/badge.svg)](https://github.com/jhnc-oss/yocto-build/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+gitrepo


### PR DESCRIPTION
Initial CI build support (#1):

- Installation of repotool
- Poky setup (stub, replaced by #2)
- Simple bitbake

#### ⚠️  Note:

While GH Actions requires `root` user ([doc](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user)), Bitbake doesn't allow it.

Therefore bitbake commands use `/opt/yocto/` as working directory and run with a `yocto` user shell (as in the image).