### PR TITLE
Switch to poky/dunfell-23.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           pip install -r requirements.txt
       - name: Build
         run: |
-          repo init -u git://github.com/jhnc-oss/yocto-manifests.git -b main
+          repo init -u git://github.com/jhnc-oss/yocto-manifests.git -b dunfell-23.0.9
           repo sync
           source poky/oe-init-build-env
           bitbake -p zlib


### PR DESCRIPTION
Our objective is to follow and stay in sync with poky/dunfell (LTS Release) which latest version is 23.0.9.
Therefore, switch the default build to incorporate this version, meeting the initial commit while using the corresponding. yocto-manifests branch.