### PR TITLE
Enable meta-protos in development setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,14 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           pip install -r requirements.txt
-      - name: Build
+      - name: Synchronize Repositories
         run: |
           repo init -u git://github.com/jhnc-oss/yocto-manifests.git -b dunfell-23.0.9
           repo sync
+        shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
+        working-directory: /opt/yocto
+      - name: Build
+        run: |
           source poky/oe-init-build-env
           bitbake -p zlib
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 [![ci](https://github.com/jhnc-oss/yocto-build/actions/workflows/ci.yml/badge.svg)](https://github.com/jhnc-oss/yocto-build/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg)](LICENSE)
 
-:warning: **Ensure SELinux state is set to disabled** otherwise you very likely will face issues (cp -afl --preserver ... failing) within the podman build container due to bitbake trying to create hard-links in the course of build tasks.
-
 ## Prerequisites
-Make sure that you have installed the following prerequisites on your host machine:
+Ensure that you have installed the following prerequisites on your host machine:
 * containerd
 * podman
 
@@ -17,3 +15,22 @@ $ git clone https://github.com/jhnc-oss/yocto-build.git
 $ cd yocto-build
 $ ./dev/bootstrap.sh
 ```
+
+## Known Issues
+You may face issues with SELinux being enabled during builds resulting in
+errors such as:
+```
+Command 'cp -afl --preserve=xattr ...' failed
+```
+
+As the podman container runs unprivileged (rootless) the cause might be
+container-storage setting driver to "overlay" by default.
+Try  switching to "vfs" using the following user-specific configuration
+snippet:
+```
+$ cat ~/.config/containers/storage.conf
+[storage]
+driver = "vfs"
+```
+For further details please refer to containers-storage.conf(5).
+

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -11,6 +11,7 @@ podman run \
   --user "${YOCTO_USER}" \
   --workdir "${YOCTO_WORKDIR}" \
   -v "${PWD}"/dev:"${YOCTO_WORKDIR}"/dev \
+  --env TEMPLATECONF="${YOCTO_WORKDIR}"/meta-protos/conf/templates \
   ghcr.io/jhnc-oss/yocto-image/yocto:latest \
   bash -c 'dev/init_env.sh'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+anytree
 gitrepo


### PR DESCRIPTION
- Drop the initial word-of-warning regarding SELinux as it seems related to storage driver overlay only missing capabilities to handle hard-link operations
- Enable meta-protos in bootstrap (development build container)
- Rename CI step for repo sync
- Add anytree to requirements.txt to be used for dependency tree parsing

**Note**: This change is limited to the development bootstrap only. Therefore, CI did not verify it and manually testing via bootstrapping the development container is highly encouraged.