### PR TITLE
Map DL_DIR and SSTATE_DIR volumes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+download
+sstate

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ Ensure that you have installed the following prerequisites on your host machine:
 * containerd
 * podman
 
+The build container expects the run user's primary group to be 4040 in order
+to accomplish write access for mapped directories (DL_DIR and SSTATE_DIR)
+to outlive container termination.
+Therefore, change your run user's primary group accordingly:
+```
+sudo usermod -g 4040 $(whoami)
+```
+Though, you will be better equipped to create a dedicated run user with
+primary group id set to 4040.
+
 ## Bootstrapping the Yocto Build Container
 Run the following commands to set up the build container environment:
 ```

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+set -o errexit
+set -o pipefail
+set -o nounset
+
+[[ -d "$PWD"/download ]] || mkdir "$PWD"/download
+[[ -d "$PWD"/sstate ]] || mkdir "$PWD"/sstate
+
 YOCTO_USER="yocto"
 YOCTO_WORKDIR="/opt/${YOCTO_USER}"
+
+sudo chmod -R 775 "${PWD}"/{download,sstate}
 
 podman run \
   -ti \
@@ -11,6 +20,8 @@ podman run \
   --user "${YOCTO_USER}" \
   --workdir "${YOCTO_WORKDIR}" \
   -v "${PWD}"/dev:"${YOCTO_WORKDIR}"/dev \
+  -v "${PWD}"/download:"${YOCTO_WORKDIR}"/download \
+  -v "${PWD}"/sstate:"${YOCTO_WORKDIR}"/sstate \
   --env TEMPLATECONF="${YOCTO_WORKDIR}"/meta-protos/conf/templates \
   ghcr.io/jhnc-oss/yocto-image/yocto:latest \
   bash -c 'dev/init_env.sh'

--- a/dev/init_env.sh
+++ b/dev/init_env.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/.local/bin:$PATH"
+set -o errexit
+
 MANIFEST_BRANCH="dunfell-23.0.9"
 MANIFEST_URL="https://github.com/jhnc-oss/yocto-manifests.git"
+PATH="$HOME/.local/bin:$PATH"
 
 cat > "$HOME/.gitconfig" <<EOF
 [color]


### PR DESCRIPTION
- Map DL_DIR and SSTATE_DIR as volumes to outlive container
  termination to avoid loss of fetched sources and sstate
- Update README.md regarding expected primary group of
  podman run user to match yocto's group id 4040 in base
  container
- DL_DIR and SSTATE_DIR need to be group-writeable (0775)
- Add initial .gitignore excluding DL_DIR and SSTATE_DIR
  according to local.conf.sample of meta-protos