### PR TITLE
Switch CI to actually use meta-protos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           YOCTO_TARGET_ARCH: ${{ matrix.arch }}
         run: |
-          source poky/oe-init-build-env
+          TEMPLATECONF=/opt/yocto/meta-protos/conf/templates source poky/oe-init-build-env
           bitbake -p zlib
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto


### PR DESCRIPTION
- CI was defaulting to poky/dunfell while we aim to source
  meta-protos during builds to test integrity
- add TEMPLATECONF so oe-init-build-env picks it up