### PR TITLE
Switch to upstream to https

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           pip install -r requirements.txt
       - name: Synchronize Repositories
         run: |
-          repo init -u git://github.com/jhnc-oss/yocto-manifests.git -b dunfell-23.0.11
+          repo init -u https://github.com/jhnc-oss/yocto-manifests.git -b dunfell-23.0.11
           repo sync
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto


### PR DESCRIPTION
DRAFT: Needs update after https://github.com/jhnc-oss/yocto-manifests/pull/19 went in.