### PR TITLE
Set image version explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - x86_64
           - x86
     container:
-      image: ghcr.io/jhnc-oss/yocto-image/yocto:latest
+      image: ghcr.io/jhnc-oss/yocto-image/yocto:34
       options: --user root
     name: "Build (${{ matrix.arch }})"
     steps:


### PR DESCRIPTION
Set image version explicitly, to ensure the used version is documented and switching between commits selects the correct image for that version.