### PR TITLE
Fix arch propagation on CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,11 @@ jobs:
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto
       - name: Build
-        env:
-          YOCTO_TARGET_ARCH: ${{ matrix.arch }}
         run: |
-          TEMPLATECONF=/opt/yocto/meta-protos/conf/templates source poky/oe-init-build-env
+          export YOCTO_TARGET_ARCH=${{ matrix.arch }}
+          export BB_ENV_EXTRAWHITE=YOCTO_TARGET_ARCH
+          export TEMPLATECONF=/opt/yocto/meta-protos/conf/templates
+          source poky/oe-init-build-env
           bitbake -p zlib
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto


### PR DESCRIPTION
Exporting the envs does the trick.

closes #25 