### PR TITLE
Remove --verbose from repo sync

### DIFF
--- a/dev/init_env.sh
+++ b/dev/init_env.sh
@@ -23,7 +23,6 @@ repo init \
   --manifest-branch $MANIFEST_BRANCH
 
 repo sync \
-  --verbose \
   --jobs="$(grep -c ^proc /proc/cpuinfo)" \
   --fetch-submodules \
   --current-branch \


### PR DESCRIPTION
Removes `--verbose` from `repo sync` as it clutters the terminal.