### PR TITLE
Build 'main' by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Synchronize Repositories
         run: |
           PATH="${HOME}/.local/bin:${PATH}"
-          repo init -u https://github.com/jhnc-oss/yocto-manifests.git -b dunfell-23.0.13
+          repo init -u https://github.com/jhnc-oss/yocto-manifests.git -b main
           repo sync
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto


### PR DESCRIPTION
Build `main` by default, otherwise builds may run with an outdated branch.