### PR TITLE
Update TEMPLATECONF path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           export YOCTO_TARGET_ARCH=${{ matrix.arch }}
           export BB_ENV_EXTRAWHITE=YOCTO_TARGET_ARCH
-          export TEMPLATECONF=/opt/yocto/meta-protos/conf/templates
+          export TEMPLATECONF=/opt/yocto/protos/conf/templates
           source poky/oe-init-build-env
           bitbake-layers show-layers
           bitbake -p zlib

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -26,7 +26,7 @@ podman run \
   -v "${PWD}"/download:"${YOCTO_WORKDIR}"/download \
   -v "${PWD}"/sstate:"${YOCTO_WORKDIR}"/sstate \
   --env YOCTO_TARGET_ARCH="${YOCTO_TARGET_ARCH}" \
-  --env TEMPLATECONF="${YOCTO_WORKDIR}"/meta-protos/conf/templates \
+  --env TEMPLATECONF="${YOCTO_WORKDIR}"/protos/conf/templates \
   --env "BB_ENV_EXTRAWHITE=YOCTO_TARGET_ARCH" \
   ghcr.io/jhnc-oss/yocto-image/yocto:34 \
   bash -c "dev/init_env.sh ${MANIFEST_BRANCH}"


### PR DESCRIPTION
Updates the `TEMPLATECONF` to the new distro path (https://github.com/jhnc-oss/meta-protos/issues/79).