### PR TITLE
Use 'main' manifest on main

### DIFF
--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MANIFEST_BRANCH="${1:-kirkstone}"
+MANIFEST_BRANCH="${1:-main}"
 YOCTO_TARGET_ARCH="x86_64"
 
 YOCTO_GID="4040"

--- a/dev/init_env.sh
+++ b/dev/init_env.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-MANIFEST_BRANCH="${1:-kirkstone}"
+MANIFEST_BRANCH="${1:-main}"
 MANIFEST_URL="https://github.com/jhnc-oss/yocto-manifests.git"
 
 repo init \


### PR DESCRIPTION
Use the manifest `main` branch on `main` to stay consistent with other parts – it's `kirkstone` anyway.