### PR TITLE
Update images to Fedora 38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           - x86_64
           - x86
     container:
-      image: ghcr.io/jhnc-oss/yocto-image/yocto:36
+      image: ghcr.io/jhnc-oss/yocto-image/yocto:38
       options: --user root
     name: "Build (${{ matrix.arch }})"
     steps:

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -38,5 +38,5 @@ podman run \
   --env YOCTO_TARGET_ARCH="${YOCTO_TARGET_ARCH}" \
   --env TEMPLATECONF="${YOCTO_WORKDIR}"/protos/conf/templates \
   --env "BB_ENV_PASSTHROUGH_ADDITIONS=YOCTO_TARGET_ARCH" \
-  ghcr.io/jhnc-oss/yocto-image/yocto:36 \
+  ghcr.io/jhnc-oss/yocto-image/yocto:38 \
   bash -c "dev/init_env.sh ${MANIFEST_BRANCH}"


### PR DESCRIPTION
Updates the images to Fedora 38 (was dunfell moved to FC37 already). Even though FC38 is not officially supported on Kirkstone yet, it seems to work fine so far.

If FC38 is not an option, we should at least update to FC37 here too.