### PR TITLE
Disable broken bitbake world cron build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
           source poky/oe-init-build-env
           bitbake-layers show-layers
           bitbake -p zlib
-          if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            bitbake -n world
-          fi
+          # disabled due to #69; 'world' is broken at the moment
+          #if [[ ${{ github.event_name }} == 'schedule' ]]; then
+          #  bitbake -n world
+          #fi
         shell: sudo -u yocto bash --noprofile --norc -eo pipefail {0}
         working-directory: /opt/yocto


### PR DESCRIPTION
*world* is broken at the moment, see #69.

The cron itself remains active, but does no longer build *world*.