### PR TITLE
Switch main to scarthgap

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: jojomatik/sync-branch@v2
         with:
           source: "main"
-          target: "kirkstone"
+          target: "scarthgap"
           strategy: "fail"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ For further details please refer to containers-storage.conf(5).
 
 | Yocto Release Branch | Status | Note |
 |:--------------------:|:------:|------|
-| **`scarthgap`**      | :heavy_check_mark: LTS | |
-| **`kirkstone`**      | :heavy_check_mark: LTS | :arrows_clockwise: Synced from `main` — *do not contribute directly* |
+| **`scarthgap`**      | :heavy_check_mark: LTS | :arrows_clockwise: Synced from `main` — *do not contribute directly* |
+| **`kirkstone`**      | :heavy_check_mark: LTS | |
 | **`dunfell`**        | :heavy_check_mark: LTS | |

--- a/dev/bootstrap.sh
+++ b/dev/bootstrap.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-MANIFEST_BRANCH="${1:-main}"
+MANIFEST_BRANCH="${1:-scarthgap}"
 YOCTO_TARGET_ARCH="x86_64"
 
 YOCTO_GID="1000"
@@ -34,7 +34,7 @@ podman run \
   -v "${PWD}"/download:"${YOCTO_WORKDIR}"/download:Z \
   -v "${PWD}"/sstate:"${YOCTO_WORKDIR}"/sstate:Z \
   --env YOCTO_TARGET_ARCH="${YOCTO_TARGET_ARCH}" \
-  --env TEMPLATECONF="${YOCTO_WORKDIR}"/protos/conf/templates \
+  --env TEMPLATECONF="${YOCTO_WORKDIR}"/protos/meta-protos/conf/templates/default \
   --env "BB_ENV_PASSTHROUGH_ADDITIONS=YOCTO_TARGET_ARCH" \
   ghcr.io/jhnc-oss/yocto-image/yocto:38 \
   bash -c "dev/init_env.sh ${MANIFEST_BRANCH}"

--- a/dev/init_env.sh
+++ b/dev/init_env.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-MANIFEST_BRANCH="${1:-main}"
+MANIFEST_BRANCH="${1:-scarthgap}"
 MANIFEST_URL="https://github.com/jhnc-oss/yocto-manifests.git"
 
 repo init \


### PR DESCRIPTION
Updates `main` to `scarthgap`.

- Merges *scarthgap* into *main*
- Updates sync job

:warning: Please note: Do not contribute to *scarthgap* branch, as it's automatically synced from *main*.